### PR TITLE
Removed reply-tag when Bot is used in a Group-/ or DM-Chat

### DIFF
--- a/app.js
+++ b/app.js
@@ -88,7 +88,10 @@ function send(msg, txt){
     if (raw.bot.stealth_mode) console.log(">> ANSWER: " + txt + "\n");
     else {
         console.log(">> Sent Answer\n");
-        msg.reply(txt);
+        if(msg.channel.type === "group")
+            msg.channel.send(txt);
+        else
+            msg.reply(txt);
     }
 }
 


### PR DESCRIPTION
Fixed #1 by adding a channel-type check inside the send function.